### PR TITLE
FRT-23 fix(infra):젠킨스파일 태그생성 방식 변경

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,17 +48,17 @@ spec:
 		stage('Prepare Tag') {
 			steps {
 				script {
-					// 커밋 해시를 임시 파일(tag.txt)에 기록합니다.
 					sh 'git rev-parse --short HEAD > tag.txt'
 
-					// 파일 내용을 읽어와서 변수에 담습니다.
-					def gitCommit = readFile('tag.txt').trim()
+					// 읽어온 값을 로컬 변수에 담을 때 반드시 String으로 형변환을 강제.
+					String gitCommit = readFile('tag.txt').trim()
+					echo "1. 로컬 변수 확인: ${gitCommit}"
 
-					env.FINAL_TAG = gitCommit
-					echo "확인된 커밋 해시: ${gitCommit}"
-					echo "최종 배포 태그: ${env.FINAL_TAG}"
+					// env 객체에 직접 할당하는 대신, 젠킨스 전역 환경 변수로 다시 변경.
+					env.FINAL_TAG = gitCommit.toString()
 
-					// 사용한 임시 파일은 삭제합니다.
+					echo "2. env 객체 확인: ${env.FINAL_TAG}"
+
 					sh 'rm tag.txt'
 				}
 			}


### PR DESCRIPTION
## 변경 사항
- 젠킨스파일 태그생성 방식 변경 String으로 형변환 하여 env 객체에 직접 할당

## 작업 내용
- [ ] 기능 구현
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 테스트 추가/수정
- [x] 문서 수정
- [ ] 디자인 요소 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)

## 체크리스트
- [ ] 중요!! : run했을 때 멈추지 않고 돌아가는가
- [x] Push 전 pull dev 했는가
- [x] 불필요한 코드/주석이 없는가

## 참고 사항(생략 가능)
- 리뷰어가 알면 좋은 내용 (스크린샷, 로그, 설계 설명 등)

